### PR TITLE
Enable comparison against two recommended nutrient sets

### DIFF
--- a/src/components/diet/FoodDiary.css
+++ b/src/components/diet/FoodDiary.css
@@ -404,6 +404,15 @@
   max-height: 400px;
 }
 
+.compare-age {
+  margin-bottom: 10px;
+}
+
+.compare-age input {
+  margin-left: 5px;
+  width: 60px;
+}
+
 .no-selection {
   text-align: center;
   padding: 50px 20px;


### PR DESCRIPTION
## Summary
- add optional second age input in `FoodDiary`
- fetch additional recommended nutrient info for that age
- plot actual nutrients alongside two recommended datasets
- style comparison age input

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68411fd5e0bc8325b6ee4f4c5cfd98f3