### PR TITLE
feat: add refresh button for meal items

### DIFF
--- a/src/components/meal/DietPlan.css
+++ b/src/components/meal/DietPlan.css
@@ -197,6 +197,22 @@
   margin-bottom: 2px;
 }
 
+.refresh-button {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 12px;
+  color: #4285f4;
+  padding: 2px;
+}
+
+.refresh-button:hover {
+  color: #3367d6;
+}
+
 .has-diet-indicator {
   width: 6px;
   height: 6px;

--- a/src/components/meal/DietPlanView.jsx
+++ b/src/components/meal/DietPlanView.jsx
@@ -69,6 +69,17 @@ const DietPlanView = ({
                       onClick={() => handleDateClick(day)}
                     >
                       <div className="calendar-date">{formatDate(day)}</div>
+                      {isExpanded && (
+                        <button
+                          className="refresh-button"
+                          onClick={e => {
+                            e.stopPropagation();
+                            handleRegenerateMeal(day);
+                          }}
+                        >
+                          ↻
+                        </button>
+                      )}
                       {hasMealData(day) && isCurrentMonth(day) && (
                         <div className={`diet-summary ${isExpanded ? 'expanded-summary' : ''}`}>
                           {meals[formatDateString(day)]?.rice_name && (


### PR DESCRIPTION
## Summary
- allow regenerating meal via refresh button on expanded calendar items
- add styles for new refresh button

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unnecessary try/catch wrapper and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6890be7f5e0c832596f9b95e231be845