### PR TITLE
feat: add refresh button for meal items

### DIFF
--- a/src/components/meal/DietPlan.css
+++ b/src/components/meal/DietPlan.css
@@ -197,6 +197,22 @@
   margin-bottom: 2px;
 }
 
+.refresh-button {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 12px;
+  color: #4285f4;
+  padding: 2px;
+}
+
+.refresh-button:hover {
+  color: #3367d6;
+}
+
 .has-diet-indicator {
   width: 6px;
   height: 6px;
@@ -229,14 +245,35 @@
 }
 
 .diet-item {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
   margin-bottom: 2px;
   padding: 3px 4px;
   border-radius: 3px;
   font-size: 9px;
   line-height: 1.3;
+}
+
+.diet-item-name {
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.item-refresh-button {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 10px;
+  color: #4285f4;
+  padding: 0;
+  margin-left: 4px;
+}
+
+.item-refresh-button:hover {
+  color: #3367d6;
 }
 
 .diet-item.main-dish {
@@ -360,6 +397,9 @@
   padding: 5px 0;
   font-size: 14px;
   position: relative;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 }
 
 .meal-items li::before {
@@ -367,6 +407,13 @@
   color: #4285f4;
   font-weight: bold;
   margin-right: 10px;
+}
+
+.meal-item-name {
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 @media (max-width: 768px) {

--- a/src/components/meal/DietPlanView.jsx
+++ b/src/components/meal/DietPlanView.jsx
@@ -7,7 +7,7 @@ const DietPlanView = ({
   currentDate, viewType, handleViewTypeChange, generating, error,
   weekdays, days, prevMonth, nextMonth, formatMonth, expandedDate, isSameDate, isCurrentMonth, isWeekend,
   handleDateClick, hasMealData, meals, formatDateString, selectedMenuItem, handleMenuItemClick, handleFoodClick,
-  formatDate, selectedDate, formatSelectedDate, loading, selectedMeal, handleRegenerateMeal, showFoodDetail, selectedFoodId, handleCloseFoodDetail,
+  formatDate, selectedDate, formatSelectedDate, loading, selectedMeal, handleRegenerateMeal, handleRegenerateMealItem, showFoodDetail, selectedFoodId, handleCloseFoodDetail,
   showGenerateOptions, handleShowGenerateOptions, handleGenerateByType
 }) => (
   <div className="diet-plan-container">
@@ -69,42 +69,125 @@ const DietPlanView = ({
                       onClick={() => handleDateClick(day)}
                     >
                       <div className="calendar-date">{formatDate(day)}</div>
+                      {isExpanded && (
+                        <button
+                          className="refresh-button"
+                          onClick={e => {
+                            e.stopPropagation();
+                            handleRegenerateMeal(day);
+                          }}
+                        >
+                          ↻
+                        </button>
+                      )}
                       {hasMealData(day) && isCurrentMonth(day) && (
                         <div className={`diet-summary ${isExpanded ? 'expanded-summary' : ''}`}>
                           {meals[formatDateString(day)]?.rice_name && (
-                            <div className={`diet-item rice ${isExpanded && selectedMenuItem === 'rice' ? 'selected-menu-item' : ''}`}
-                              onClick={e => { e.stopPropagation(); if (isExpanded) { handleMenuItemClick(e, 'rice'); handleFoodClick(meals[formatDateString(day)].Rice_id); } }}>
-                              {meals[formatDateString(day)].rice_name}
+                            <div className={`diet-item rice ${isExpanded && selectedMenuItem === 'rice' ? 'selected-menu-item' : ''}`}>
+                              <span
+                                className="diet-item-name"
+                                onClick={e => { e.stopPropagation(); if (isExpanded) { handleMenuItemClick(e, 'rice'); handleFoodClick(meals[formatDateString(day)].Rice_id); } }}
+                              >
+                                {meals[formatDateString(day)].rice_name}
+                              </span>
+                              {isExpanded && (
+                                <button
+                                  className="item-refresh-button"
+                                  onClick={e => { e.stopPropagation(); handleRegenerateMealItem(day, 'rice'); }}
+                                >
+                                  ↻
+                                </button>
+                              )}
                             </div>
                           )}
                           {meals[formatDateString(day)]?.soup_name && (
-                            <div className={`diet-item soup ${isExpanded && selectedMenuItem === 'soup' ? 'selected-menu-item' : ''}`}
-                              onClick={e => { e.stopPropagation(); if (isExpanded) { handleMenuItemClick(e, 'soup'); handleFoodClick(meals[formatDateString(day)].Soup_id); } }}>
-                              {meals[formatDateString(day)].soup_name}
+                            <div className={`diet-item soup ${isExpanded && selectedMenuItem === 'soup' ? 'selected-menu-item' : ''}`}>
+                              <span
+                                className="diet-item-name"
+                                onClick={e => { e.stopPropagation(); if (isExpanded) { handleMenuItemClick(e, 'soup'); handleFoodClick(meals[formatDateString(day)].Soup_id); } }}
+                              >
+                                {meals[formatDateString(day)].soup_name}
+                              </span>
+                              {isExpanded && (
+                                <button
+                                  className="item-refresh-button"
+                                  onClick={e => { e.stopPropagation(); handleRegenerateMealItem(day, 'soup'); }}
+                                >
+                                  ↻
+                                </button>
+                              )}
                             </div>
                           )}
                           {meals[formatDateString(day)]?.main_dish_name && (
-                            <div className={`diet-item main-dish ${isExpanded && selectedMenuItem === 'main_dish' ? 'selected-menu-item' : ''}`}
-                              onClick={e => { e.stopPropagation(); if (isExpanded) { handleMenuItemClick(e, 'main_dish'); handleFoodClick(meals[formatDateString(day)].MainDish_id); } }}>
-                              {meals[formatDateString(day)].main_dish_name}
+                            <div className={`diet-item main-dish ${isExpanded && selectedMenuItem === 'main_dish' ? 'selected-menu-item' : ''}`}>
+                              <span
+                                className="diet-item-name"
+                                onClick={e => { e.stopPropagation(); if (isExpanded) { handleMenuItemClick(e, 'main_dish'); handleFoodClick(meals[formatDateString(day)].MainDish_id); } }}
+                              >
+                                {meals[formatDateString(day)].main_dish_name}
+                              </span>
+                              {isExpanded && (
+                                <button
+                                  className="item-refresh-button"
+                                  onClick={e => { e.stopPropagation(); handleRegenerateMealItem(day, 'main_dish'); }}
+                                >
+                                  ↻
+                                </button>
+                              )}
                             </div>
                           )}
                           {meals[formatDateString(day)]?.side_dish1_name && (
-                            <div className={`diet-item side-dish ${isExpanded && selectedMenuItem === 'side_dish1' ? 'selected-menu-item' : ''}`}
-                              onClick={e => { e.stopPropagation(); if (isExpanded) { handleMenuItemClick(e, 'side_dish1'); handleFoodClick(meals[formatDateString(day)].SideDish1_id); } }}>
-                              {meals[formatDateString(day)].side_dish1_name}
+                            <div className={`diet-item side-dish ${isExpanded && selectedMenuItem === 'side_dish1' ? 'selected-menu-item' : ''}`}>
+                              <span
+                                className="diet-item-name"
+                                onClick={e => { e.stopPropagation(); if (isExpanded) { handleMenuItemClick(e, 'side_dish1'); handleFoodClick(meals[formatDateString(day)].SideDish1_id); } }}
+                              >
+                                {meals[formatDateString(day)].side_dish1_name}
+                              </span>
+                              {isExpanded && (
+                                <button
+                                  className="item-refresh-button"
+                                  onClick={e => { e.stopPropagation(); handleRegenerateMealItem(day, 'side_dish1'); }}
+                                >
+                                  ↻
+                                </button>
+                              )}
                             </div>
                           )}
                           {meals[formatDateString(day)]?.side_dish2_name && (
-                            <div className={`diet-item side-dish2 ${isExpanded && selectedMenuItem === 'side_dish2' ? 'selected-menu-item' : ''}`}
-                              onClick={e => { e.stopPropagation(); if (isExpanded) { handleMenuItemClick(e, 'side_dish2'); handleFoodClick(meals[formatDateString(day)].SideDish2_id); } }}>
-                              {meals[formatDateString(day)].side_dish2_name}
+                            <div className={`diet-item side-dish2 ${isExpanded && selectedMenuItem === 'side_dish2' ? 'selected-menu-item' : ''}`}>
+                              <span
+                                className="diet-item-name"
+                                onClick={e => { e.stopPropagation(); if (isExpanded) { handleMenuItemClick(e, 'side_dish2'); handleFoodClick(meals[formatDateString(day)].SideDish2_id); } }}
+                              >
+                                {meals[formatDateString(day)].side_dish2_name}
+                              </span>
+                              {isExpanded && (
+                                <button
+                                  className="item-refresh-button"
+                                  onClick={e => { e.stopPropagation(); handleRegenerateMealItem(day, 'side_dish2'); }}
+                                >
+                                  ↻
+                                </button>
+                              )}
                             </div>
                           )}
                           {meals[formatDateString(day)]?.dessert_name && (
-                            <div className={`diet-item dessert ${isExpanded && selectedMenuItem === 'dessert' ? 'selected-menu-item' : ''}`}
-                              onClick={e => { e.stopPropagation(); if (isExpanded) { handleMenuItemClick(e, 'dessert'); handleFoodClick(meals[formatDateString(day)].Dessert_id); } }}>
-                              {meals[formatDateString(day)].dessert_name}
+                            <div className={`diet-item dessert ${isExpanded && selectedMenuItem === 'dessert' ? 'selected-menu-item' : ''}`}>
+                              <span
+                                className="diet-item-name"
+                                onClick={e => { e.stopPropagation(); if (isExpanded) { handleMenuItemClick(e, 'dessert'); handleFoodClick(meals[formatDateString(day)].Dessert_id); } }}
+                              >
+                                {meals[formatDateString(day)].dessert_name}
+                              </span>
+                              {isExpanded && (
+                                <button
+                                  className="item-refresh-button"
+                                  onClick={e => { e.stopPropagation(); handleRegenerateMealItem(day, 'dessert'); }}
+                                >
+                                  ↻
+                                </button>
+                              )}
                             </div>
                           )}
                         </div>
@@ -140,7 +223,10 @@ const DietPlanView = ({
             <div className="meal-block">
               <h3 className="meal-title">밥</h3>
               <ul className="meal-items">
-                <li onClick={() => handleFoodClick(selectedMeal.rice_id)} className="food-item-clickable">{selectedMeal.rice_name}</li>
+                <li className="meal-item">
+                  <span className="meal-item-name food-item-clickable" onClick={() => handleFoodClick(selectedMeal.rice_id)}>{selectedMeal.rice_name}</span>
+                  <button className="item-refresh-button" onClick={() => handleRegenerateMealItem(selectedDate, 'rice')}>↻</button>
+                </li>
               </ul>
             </div>
           )}
@@ -148,7 +234,10 @@ const DietPlanView = ({
             <div className="meal-block">
               <h3 className="meal-title">국/찌개</h3>
               <ul className="meal-items">
-                <li onClick={() => handleFoodClick(selectedMeal.soup_id)} className="food-item-clickable">{selectedMeal.soup_name}</li>
+                <li className="meal-item">
+                  <span className="meal-item-name food-item-clickable" onClick={() => handleFoodClick(selectedMeal.soup_id)}>{selectedMeal.soup_name}</span>
+                  <button className="item-refresh-button" onClick={() => handleRegenerateMealItem(selectedDate, 'soup')}>↻</button>
+                </li>
               </ul>
             </div>
           )}
@@ -157,10 +246,16 @@ const DietPlanView = ({
               <h3 className="meal-title">반찬</h3>
               <ul className="meal-items">
                 {selectedMeal.side_dish1_id && (
-                  <li onClick={() => handleFoodClick(selectedMeal.side_dish1_id)} className="food-item-clickable">{selectedMeal.side_dish1_name}</li>
+                  <li className="meal-item">
+                    <span className="meal-item-name food-item-clickable" onClick={() => handleFoodClick(selectedMeal.side_dish1_id)}>{selectedMeal.side_dish1_name}</span>
+                    <button className="item-refresh-button" onClick={() => handleRegenerateMealItem(selectedDate, 'side_dish1')}>↻</button>
+                  </li>
                 )}
                 {selectedMeal.side_dish2_id && (
-                  <li onClick={() => handleFoodClick(selectedMeal.side_dish2_id)} className="food-item-clickable">{selectedMeal.side_dish2_name}</li>
+                  <li className="meal-item">
+                    <span className="meal-item-name food-item-clickable" onClick={() => handleFoodClick(selectedMeal.side_dish2_id)}>{selectedMeal.side_dish2_name}</span>
+                    <button className="item-refresh-button" onClick={() => handleRegenerateMealItem(selectedDate, 'side_dish2')}>↻</button>
+                  </li>
                 )}
               </ul>
             </div>
@@ -169,7 +264,10 @@ const DietPlanView = ({
             <div className="meal-block">
               <h3 className="meal-title">메인요리</h3>
               <ul className="meal-items">
-                <li onClick={() => handleFoodClick(selectedMeal.main_dish_id)} className="food-item-clickable">{selectedMeal.main_dish_name}</li>
+                <li className="meal-item">
+                  <span className="meal-item-name food-item-clickable" onClick={() => handleFoodClick(selectedMeal.main_dish_id)}>{selectedMeal.main_dish_name}</span>
+                  <button className="item-refresh-button" onClick={() => handleRegenerateMealItem(selectedDate, 'main_dish')}>↻</button>
+                </li>
               </ul>
             </div>
           )}
@@ -177,7 +275,10 @@ const DietPlanView = ({
             <div className="meal-block">
               <h3 className="meal-title">디저트</h3>
               <ul className="meal-items">
-                <li onClick={() => handleFoodClick(selectedMeal.dessert_id)} className="food-item-clickable">{selectedMeal.dessert_name}</li>
+                <li className="meal-item">
+                  <span className="meal-item-name food-item-clickable" onClick={() => handleFoodClick(selectedMeal.dessert_id)}>{selectedMeal.dessert_name}</span>
+                  <button className="item-refresh-button" onClick={() => handleRegenerateMealItem(selectedDate, 'dessert')}>↻</button>
+                </li>
               </ul>
             </div>
           )}

--- a/src/components/meal/useDietPlan.js
+++ b/src/components/meal/useDietPlan.js
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { getMonthlyMeals, generateMonthlyMeals, regenerateMeal } from '../../services/mealService';
+import { getMonthlyMeals, generateMonthlyMeals, regenerateMeal, regenerateMealItem } from '../../services/mealService';
 import axios from 'axios';
 
 export default function useDietPlan() {
@@ -77,6 +77,27 @@ export default function useDietPlan() {
       }
     } catch (err) {
       setError('서버에 연결할 수 없거나 식단 재생성에 실패했습니다.');
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleRegenerateMealItem = async (date, itemType) => {
+    try {
+      setLoading(true);
+      const dateString = formatDateString(date);
+      const response = await regenerateMealItem(dateString, itemType);
+      if (response.success) {
+        loadMeals();
+        if (response.meal) {
+          setSelectedMeal(response.meal);
+        }
+      } else {
+        setError(response.message || '메뉴 재생성에 실패했습니다.');
+      }
+    } catch (err) {
+      setError('서버에 연결할 수 없거나 메뉴 재생성에 실패했습니다.');
       console.error(err);
     } finally {
       setLoading(false);
@@ -283,7 +304,7 @@ export default function useDietPlan() {
     meals, setMeals, selectedMeal, setSelectedMeal, loading, setLoading, error, setError,
     generating, setGenerating, expandedDate, setExpandedDate, selectedMenuItem, setSelectedMenuItem,
     selectedFoodId, setSelectedFoodId, showFoodDetail, setShowFoodDetail,
-    loadMeals, handleGenerateMeals, handleRegenerateMeal, getDaysInMonth, handleDateClick,
+    loadMeals, handleGenerateMeals, handleRegenerateMeal, handleRegenerateMealItem, getDaysInMonth, handleDateClick,
     handleMenuItemClick, handleFoodClick, handleCloseFoodDetail, prevMonth, nextMonth, goToToday,
     formatDate, formatDateString, formatMonth, formatSelectedDate, isSameDate, isCurrentMonth, isWeekend,
     handleViewTypeChange, hasMealData, weekdays, days,

--- a/src/services/mealService.js
+++ b/src/services/mealService.js
@@ -115,22 +115,37 @@ export const regenerateMeal = async (date) => {
   }
 };
 
-export const getMealNutritionByDate = async (date, token) => {
+// 특정 메뉴만 다시 생성하기
+export const regenerateMealItem = async (date, itemType) => {
   try {
-    const response = await fetch(
-      `${API_URL}/meal-nutrition/${date}`,
-      {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: token ? `Bearer ${token}` : undefined,
-        },
-      }
+    const authHeader = getAuthHeader();
+    const response = await axios.post(
+      `${API_URL}/meals/regenerate/${date}/${itemType}`,
+      {},
+      authHeader
     );
-    const data = await response.json();
-    if (!response.ok) throw new Error(data.message || '영양소 정보 조회 실패');
-    return data;
+    return response.data;
   } catch (error) {
+    console.error('개별 메뉴 재생성 오류:', error);
+    if (error.response) {
+      console.error('서버 응답:', error.response.status, error.response.data);
+    }
     throw error;
   }
+};
+
+export const getMealNutritionByDate = async (date, token) => {
+  const response = await fetch(
+    `${API_URL}/meal-nutrition/${date}`,
+    {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: token ? `Bearer ${token}` : undefined,
+      },
+    }
+  );
+  const data = await response.json();
+  if (!response.ok) throw new Error(data.message || '영양소 정보 조회 실패');
+  return data;
 };


### PR DESCRIPTION
## Summary
- allow regenerating meal via refresh button on expanded calendar items
- add styles for new refresh button
- enable per-dish refresh with new API, service, and UI buttons

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: multiple lint errors across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_6890be7f5e0c832596f9b95e231be845